### PR TITLE
Update the Netherlands

### DIFF
--- a/lib/income_tax/countries/netherlands.rb
+++ b/lib/income_tax/countries/netherlands.rb
@@ -4,10 +4,48 @@ module IncomeTax
       register "Netherlands", "NL", "NLD"
       currency "EUR"
 
-      level 19645, "5.85%"
-      level 33363, "10.85%"
-      level 55991, "42%"
-      remainder "52%"
+      wants_options :birthday
+
+      levels year: 2016 do
+        level 19_922, "36.55%"
+        level 33_715, "40.4%"
+        level 66_421, "40.4%"
+        remainder "52%"
+      end
+
+      levels :fixed_aow_age, year: 2016 do
+        level 19_922, "18.65%"
+        level 34_027, "22.5%"
+        level 66_421, "40.4%"
+        remainder "52%"
+      end
+
+      levels :progressive_aow_age, year: 2016 do
+        level 19_922, "18.65%"
+        level 33_715, "22.5%"
+        level 66_421, "40.4%"
+        remainder "52%"
+      end
+
+      def level_category
+        if fixed_aow_age_reached?
+          :fixed_aow_age
+        elsif progressive_aow_age_reached?
+          :progressive_aow_age
+        else
+          :default
+        end
+      end
+
+      private
+
+      def fixed_aow_age_reached?
+        birthday < Date.new(1946, 1, 1) if birthday
+      end
+
+      def progressive_aow_age_reached?
+        birthday < Date.new(1951, 6, 30) if birthday
+      end
     end
   end
 end

--- a/locations.md
+++ b/locations.md
@@ -1227,7 +1227,7 @@ Using a progressive tax model.
 ### Netherlands
 * **Other accepted names:** "NL", "NLD"
 * **Currency:** EUR
-* **Available options:** `tax_year`
+* **Available options:** `tax_year`, `birth_day`
 
 Using a progressive tax model.
 

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ IncomeTax.new("TZ", "16m", location: "Zanzibar")
 * **`joint_statement`:** If married, whether or not both spouses file a joint statement. Respected by the U.S. American tax model.
 * **`head_of_household`:** Whether or not the tax payer is the head of the household. Respected by the U.S. American tax model.
 * **`self_employed`:** Whether the tax payer is employed or freelancing. Respected by the Costa Rican and Nicaraguan tax model.
-* **`age` or `birthday`:** To determine age depended taxes. Respected by the Australian, Bangladeshi and Barbadian tax model.
+* **`age` or `birthday`:** To determine age depended taxes. Respected by the Australian, Bangladeshi, Barbadian and Dutch tax model.
 * **`gender`:** `male` or `female`, respected by the Bangladeshi tax model.
 * **`disabled`:** Whether or not the tax payer has a physical or psychological disability, respected by the Bangladeshi tax model.
 * **`wounded_freedom_fighter`:** Whether or not the tax payer is a war-wounded freedom fighter, respected by the Bangladeshi tax model.

--- a/spec/income_tax/countries/netherlands_spec.rb
+++ b/spec/income_tax/countries/netherlands_spec.rb
@@ -1,99 +1,173 @@
 describe IncomeTax::Countries::Netherlands do
   subject(:result) { described_class.new(income: income, income_type: type, tax_year: tax_year) }
-  let(:type) { :gross }
 
-  describe "from gross income of 0" do
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 0                                         }
-    its(:rate)         { should be == Rational(0, 1)               }
-    its(:gross_income) { should be == 0                            }
-    its(:net_income)   { should be == 0                            }
-    its(:taxes)        { should be == 0                            }
-  end
+  context "tax year 2016" do
+    let(:tax_year) { 2016 }
 
-  describe "from gross income of 1000" do
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 1000                                      }
-    its(:rate)         { should be == Rational(21, 359)            }
-    its(:gross_income) { should be == 1000                         }
-    its(:net_income)   { should be == "941.5".to_d                 }
-    its(:taxes)        { should be == "58.5".to_d                  }
-  end
+    context "gross income" do
+      let(:type) { :gross }
 
-  describe "from gross income of 10000" do
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 10000                                     }
-    its(:rate)         { should be == Rational(21, 359)            }
-    its(:gross_income) { should be == 10000                        }
-    its(:net_income)   { should be == 9415                         }
-    its(:taxes)        { should be == 585                          }
-  end
+      context "AOW age not reached" do
+        describe "of 0" do
+          let(:income) { 0 }
+          its(:rate) { is_expected.to eq(Rational(0, 1)) }
+          its(:gross_income) { is_expected.to eq(0) }
+          its(:net_income) { is_expected.to eq(0) }
+          its(:taxes) { is_expected.to eq(0) }
+        end
 
-  describe "from gross income of 100000" do
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 100000                                    }
-    its(:rate)         { should be == Rational(69, 197)            }
-    its(:gross_income) { should be == 100000                       }
-    its(:net_income)   { should be == "64973.9245".to_d            }
-    its(:taxes)        { should be == "35026.0755".to_d            }
-  end
+        describe "of 1000" do
+          let(:income) { 1000 }
+          its(:rate) { is_expected.to eq(Rational(125, 342)) }
+          its(:gross_income) { is_expected.to eq(1000) }
+          its(:net_income) { is_expected.to eq("634.5".to_d) }
+          its(:taxes) { is_expected.to eq("365.5".to_d) }
+        end
 
-  describe "from gross income of 100000000" do
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 100000000                                 }
-    its(:rate)         { should be == Rational(118, 227)           }
-    its(:gross_income) { should be == 100000000                    }
-    its(:net_income)   { should be == "48016973.9245".to_d         }
-    its(:taxes)        { should be == "51983026.0755".to_d         }
-  end
+        describe "of 10000" do
+          let(:income) { 10000 }
+          its(:rate) { is_expected.to eq(Rational(125, 342)) }
+          its(:gross_income) { is_expected.to eq(10000) }
+          its(:net_income) { is_expected.to eq(6345) }
+          its(:taxes) { is_expected.to eq(3655) }
+        end
 
-  describe "from net income of 0" do
-    let(:type)         { :net                                      }
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 0                                         }
-    its(:rate)         { should be == Rational(0, 1)               }
-    its(:gross_income) { should be == 0                            }
-    its(:net_income)   { should be == 0                            }
-    its(:taxes)        { should be == 0                            }
-  end
+        describe "of 100000" do
+          let(:income) { 100000 }
+          its(:rate) { is_expected.to eq(Rational(232, 533)) }
+          its(:gross_income) { is_expected.to eq(100000) }
+          its(:net_income) { is_expected.to eq("56471.833".to_d) }
+          its(:taxes) { is_expected.to eq("43528.167".to_d) }
+        end
 
-  describe "from net income of 1000" do
-    let(:type)         { :net                                      }
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 1000                                      }
-    its(:rate)         { should be == Rational(21, 359)            }
-    its(:gross_income) { should be == "1062.13489113117366".to_d   }
-    its(:net_income)   { should be == 1000                         }
-    its(:taxes)        { should be == "62.134891131173659".to_d    }
-  end
+        describe "of 100000000" do
+          let(:income) { 100000000 }
+          its(:rate) { is_expected.to eq(Rational(222, 427)) }
+          its(:gross_income) { is_expected.to eq(100000000) }
+          its(:net_income) { is_expected.to eq("48008471.833".to_d) }
+          its(:taxes) { is_expected.to eq("51991528.167".to_d) }
+        end
+      end
 
-  describe "from net income of 10000" do
-    let(:type)         { :net                                      }
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 10000                                     }
-    its(:rate)         { should be == Rational(21, 359)            }
-    its(:gross_income) { should be == "10621.3489113117366".to_d   }
-    its(:net_income)   { should be == 10000                        }
-    its(:taxes)        { should be == "621.34891131173659".to_d    }
-  end
+      context "AOW age reached" do
+        subject(:result) { described_class.new(income: income, income_type: type, tax_year: tax_year, birthday: birthday) }
 
-  describe "from net income of 100000" do
-    let(:type)         { :net                                      }
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 100000                                    }
-    its(:rate)         { should be == Rational(27, 64)             }
-    its(:gross_income) { should be == "172970.990625".to_d         }
-    its(:net_income)   { should be == 100000                       }
-    its(:taxes)        { should be == "72970.990625".to_d          }
-  end
+        context "born before 1946" do
+          let(:birthday) { Date.new(1939, 12, 31) }
 
-  describe "from net income of 100000000" do
-    let(:type)         { :net                                      }
-    let(:tax_year)     { 2015                                      }
-    let(:income)       { 100000000                                 }
-    its(:rate)         { should be == Rational(235, 452)           }
-    its(:gross_income) { should be == "208297970.990625".to_d      }
-    its(:net_income)   { should be == 100000000                    }
-    its(:taxes)        { should be == "108297970.990625".to_d      }
+          describe "of 0" do
+            let(:income) { 0 }
+            its(:rate) { is_expected.to eq(Rational(0, 1)) }
+            its(:gross_income) { is_expected.to eq(0) }
+            its(:net_income) { is_expected.to eq(0) }
+            its(:taxes) { is_expected.to eq(0) }
+          end
+
+          describe "of 1000" do
+            let(:income) { 1000 }
+            its(:rate) { is_expected.to eq(Rational(47, 252)) }
+            its(:gross_income) { is_expected.to eq(1000) }
+            its(:net_income) { is_expected.to eq("813.5".to_d) }
+            its(:taxes) { is_expected.to eq("186.5".to_d) }
+          end
+
+          describe "of 10000" do
+            let(:income) { 10000 }
+            its(:rate) { is_expected.to eq(Rational(47, 252)) }
+            its(:gross_income) { is_expected.to eq(10000) }
+            its(:net_income) { is_expected.to eq(8135) }
+            its(:taxes) { is_expected.to eq(1865) }
+          end
+
+          describe "of 100000" do
+            let(:income) { 100000 }
+            its(:rate) { is_expected.to eq(Rational(149, 398)) }
+            its(:gross_income) { is_expected.to eq(100000) }
+            its(:net_income) { is_expected.to eq("62562.666".to_d) }
+            its(:taxes) { is_expected.to eq("37437.334".to_d) }
+          end
+        end
+
+        context "born after January 1st 1946 and before October 1950" do
+          let(:birthday) { Date.new(1950, 9, 30) }
+
+          describe "of 0" do
+            let(:income) { 0 }
+            its(:rate) { is_expected.to eq(Rational(0, 1)) }
+            its(:gross_income) { is_expected.to eq(0) }
+            its(:net_income) { is_expected.to eq(0) }
+            its(:taxes) { is_expected.to eq(0) }
+          end
+
+          describe "of 1000" do
+            let(:income) { 1000 }
+            its(:rate) { is_expected.to eq(Rational(47, 252)) }
+            its(:gross_income) { is_expected.to eq(1000) }
+            its(:net_income) { is_expected.to eq("813.5".to_d) }
+            its(:taxes) { is_expected.to eq("186.5".to_d) }
+          end
+
+          describe "of 10000" do
+            let(:income) { 10000 }
+            its(:rate) { is_expected.to eq(Rational(47, 252)) }
+            its(:gross_income) { is_expected.to eq(10000) }
+            its(:net_income) { is_expected.to eq(8135) }
+            its(:taxes) { is_expected.to eq(1865) }
+          end
+
+          describe "of 100000" do
+            let(:income) { 100000 }
+            its(:rate) { is_expected.to eq(Rational(601, 1603)) }
+            its(:gross_income) { is_expected.to eq(100000) }
+            its(:net_income) { is_expected.to eq("62506.818".to_d) }
+            its(:taxes) { is_expected.to eq("37493.182".to_d) }
+          end
+        end
+      end
+    end
+
+    context "net income" do
+      let(:type) { :net }
+
+      describe "of 0" do
+        let(:income) { 0 }
+        its(:rate) { is_expected.to eq(Rational(0, 1)) }
+        its(:gross_income) { is_expected.to eq(0) }
+        its(:net_income) { is_expected.to eq(0) }
+        its(:taxes) { is_expected.to eq(0) }
+      end
+
+      describe "of 1000" do
+        let(:income) { 1000 }
+        its(:rate) { is_expected.to eq(Rational(125, 342)) }
+        its(:gross_income) { is_expected.to eq("1576.0441292356186".to_d) }
+        its(:net_income) { is_expected.to eq(1000) }
+        its(:taxes) { is_expected.to eq("576.0441292356186".to_d) }
+      end
+
+      describe "of 10000" do
+        let(:income) { 10000 }
+        its(:rate) { is_expected.to eq(Rational(125, 342)) }
+        its(:gross_income) { is_expected.to eq("15760.441292356186".to_d) }
+        its(:net_income) { is_expected.to eq(10000) }
+        its(:taxes) { is_expected.to eq("5760.441292356186".to_d) }
+      end
+
+      describe "of 100000" do
+        let(:income) { 100000 }
+        its(:rate) { is_expected.to eq(Rational(146, 307)) }
+        its(:gross_income) { is_expected.to eq("190683.68125".to_d) }
+        its(:net_income) { is_expected.to eq(100000) }
+        its(:taxes) { is_expected.to eq("90683.68125".to_d) }
+      end
+
+      describe "of 100000000" do
+        let(:income) { 100000000 }
+        its(:rate) { is_expected.to eq(Rational(417, 802)) }
+        its(:gross_income) { is_expected.to eq("208315683.68125".to_d) }
+        its(:net_income) { is_expected.to eq(100000000) }
+        its(:taxes) { is_expected.to eq("108315683.68125".to_d) }
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm not sure where you got the old levels from, we have to pay quite a bit more I'm afraid 😞  Here's a link to the Tax and Customs Administration site for [the default levels](http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/prive/inkomstenbelasting/heffingskortingen_boxen_tarieven/boxen_en_tarieven/overzicht_tarieven_en_schijven/u_hebt_in_2016_de_aow_leeftijd_nog_niet_bereikt).

We do have a bunch of tax credits for lower incomes but I'm unsure what the best way is to add them in the gem. If your gross income is 10k you actually get money back from the tax administration because of this. The gem seems unprepared for this right now (`Models::Generic#validate` will likely throw an error). Do you have any tips?
